### PR TITLE
db1: Update boot partition index in coffee file

### DIFF
--- a/db1.coffee
+++ b/db1.coffee
@@ -24,7 +24,7 @@ module.exports =
 	configuration:
 		config:
 			partition:
-				primary: 1
+				primary: 7
 			path: '/config.json'
 
 	initialization: commonImg.initialization


### PR DESCRIPTION
According to https://github.com/bluechiptechnology/meta-db1/blob/537a8d0a23bd983d28d70876dcdbd0fa4611bec7/recipes-bsp/u-boot/files/partition_specification.txt, the boot partition has index 7 for both the flasher and non-flasher images.

Changelog-entry: db1: Update boot partition index in coffee file